### PR TITLE
Rename the gem back to default name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Create Gem
         run: |
-          gem build ruby-debug-ide.gemspec -o corigbytes-ruby-debug-ide-${{ steps.calculate_version.outputs.semver }}.gem
+          gem build ruby-debug-ide.gemspec -o ruby-debug-ide-${{ steps.calculate_version.outputs.semver }}.gem
 
       - name: Upload GitHub Workflow Artifacts
         uses: actions/upload-artifact@v2

--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -228,7 +228,8 @@ module Debugger
       3.times do |i|
         unless connected
           begin
-            s = TCPSocket.open(acceptor_host, acceptor_port)
+            print_debug "notify_dispatcher_if_needed"
+            s = TCPSocket.open('host.docker.internal', acceptor_port)
             dispatcher_answer = s.gets.chomp
 
             if dispatcher_answer == "true"

--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -224,8 +224,7 @@ module Debugger
       3.times do |i|
         unless connected
           begin
-            print_debug "notify_dispatcher_if_needed"
-            s = TCPSocket.open('host.docker.internal', acceptor_port)
+            s = TCPSocket.open(acceptor_host, acceptor_port)
             dispatcher_answer = s.gets.chomp
 
             if dispatcher_answer == "true"

--- a/ruby-debug-ide.gemspec
+++ b/ruby-debug-ide.gemspec
@@ -20,7 +20,7 @@ unless defined? FILES
 end
 
 Gem::Specification.new do |spec|
-  spec.name = "corgibytes-ruby-debug-ide"
+  spec.name = "ruby-debug-ide"
 
   spec.homepage = "https://github.com/corgibytes/ruby-debug-ide"
   spec.summary = "IDE interface for ruby-debug."


### PR DESCRIPTION
Need to rename the gem back from `corgibytes_ruby-debug-ide` to `ruby-debug-ide`.  RubyMine will only use a gem that is called `ruby-debug-ide`.